### PR TITLE
chore(YouHaveTrouble): remove plugin breaking option

### DIFF
--- a/src/main/resources/profiles/YouHaveTrouble.kos
+++ b/src/main/resources/profiles/YouHaveTrouble.kos
@@ -172,7 +172,6 @@ paper:
       creative: 20
   redstone-implementation: ALTERNATE_CURRENT
   hoppers:
-    disable-move-event: true
     ignore-occluding-blocks: true
   optimise-explosions: true
   find-already-discovered-loot-tables: false


### PR DESCRIPTION
The Disable Hopper Move config breaks almost every single protection plugin and is not recommended in most implementations