### PR TITLE
chore(FarmFriendly): remove plugin breaking config option

### DIFF
--- a/src/main/resources/profiles/FarmFriendly.kos
+++ b/src/main/resources/profiles/FarmFriendly.kos
@@ -171,7 +171,6 @@ paper:
       creative: 20
   redstone-implementation: ALTERNATE_CURRENT
   hoppers:
-    disable-move-event: true
     ignore-occluding-blocks: true
   optimise-explosions: true
   find-already-discovered-loot-tables: true


### PR DESCRIPTION
The Disable Hopper Move config breaks almost every single protection plugin and is not recommended in most implementations